### PR TITLE
Add function to fetch historical equity data

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-from nse import NSE
+from .nse import NSE

--- a/src/nse/NSE.py
+++ b/src/nse/NSE.py
@@ -182,7 +182,8 @@ class NSE:
 
     @staticmethod
     def __split_date_range(from_date: date, to_date: date, max_chunk_size: int=365) -> List[Tuple[date, date]]:
-        """Splits a date range into non-overlapping chunks with each chunk having size at max 1 calendar year
+        """Splits a date range into non-overlapping chunks with each chunk having size at specified by 
+        the max_chunk_size parameter
         
         :param from_date: The starting date of the range
         :type from_date: datetime.date
@@ -198,12 +199,18 @@ class NSE:
         chunks = []
         current_start = from_date
         
-        while current_start < to_date:
-            current_end = min(current_start + timedelta(days=max_chunk_size), to_date)
+        while current_start <= to_date:
+            # Calculate the end of the current chunk.
+            # We use max_size - 1 because the range is inclusive.
+            current_end = current_start + timedelta(days=max_chunk_size - 1)
+            # Don't go past the final date.
+            if current_end > to_date:
+                current_end = to_date
             chunks.append((current_start, current_end))
-            current_start = current_end  # Move to the next chunk start
-
-        return chunks      
+            # Start next chunk the day after the current end.
+            current_start = current_end + timedelta(days=1)
+        
+        return chunks     
 
     def exit(self):
         """Close the ``requests`` session.
@@ -1341,6 +1348,7 @@ class NSE:
         date_chunks: List[Tuple[date, date]] = NSE.__split_date_range(from_date, to_date, 100)
         data = []
         for chunk in date_chunks:
+            print(chunk)
             data += reversed(self.__req(
                 url=f"{self.base_url}/historical/cm/equity",
                 params={


### PR DESCRIPTION
The major change in this PR is the addition of a function `fetch_equity_historical_data` to pull the historical data for equity symbols which includes daily OHLC, LTP, 52W High, 52W Low, Volume, Traded Value, Number of Trades and Corporate Adjustment among the key columns fetched. This function takes the symbol, the starting and ending dates as well as the series for which we need to fetch the data. It performs some preliminary sanity checks (throwing exceptions in case of failure) and then proceeds to fetch the data table for the dates. The function is especially powerful because of it's ability to fetch data for a fairly long horizon by splitting the date range into chunks and making separate API calls for each range, since NSE returns at max only 70 rows per API call and rejects the request if the date range exceeds 1 year. 

![image](https://github.com/user-attachments/assets/3f813186-2026-4b08-aa9c-6964c43d2610)
An example of the type of data fetched

At the time of development, testing by fetching historical EQ series data for "INFY" from 01-01-2019 to 31-12-2024 works flawlessly without running into any rate-limitation or blocking. On timing a script which creates an `NSE` object and calls the function for the above dates with Linux's `time script.py` dumps the following statistics
```
real    0m7.393s
user    0m1.691s
sys     0m0.074s
```
This proves that the script is sufficiently fast and most of the time is taken to fetch an API response. I expect the script to work fine and comfortably fetch up-to 10 years of data without hiccups. 

There are two minor changes pushed for this PR.

1. The `__init__.py` file in `src`, [here](https://github.com/BennyThadikaran/NseIndiaApi/blob/main/src/__init__.py) uses absolute import instead of relative import to the `src` directory. This goes against best practices. Using a relative import allows developers to import the top level `src` module as long as it is in the PATH, thus making testing easier. 
2. A helper static function has been added which takes as input a start date and end date and splits the range into non-overlapping, chronologically sorted chunks of max size specified by an optional chunk size parameter. This function can be used in all other cases where NSE allows only a limited number of rows to be fetched to fetch longer term data by making multiple API calls. 