### PR TITLE
Added support for the library to support connections from server environments

### DIFF
--- a/src/nse/NSE.py
+++ b/src/nse/NSE.py
@@ -2,7 +2,6 @@ import json
 import pickle
 import zlib
 from datetime import date, datetime, timedelta
-import time
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 from zipfile import ZipFile


### PR DESCRIPTION
I am opening this pull request in response to #9. As discussed in the issue, NSE seems to disallow connections from server environments when using HTTP/1.1, which is the default for the `requests` library. As a solution, I've tried to rewrite some of the base methods using the `httpx` library which supports HTTP/2 with minimal code changes. Like the `Session` class of `requests`, `httpx` provides a `Client` class which allows for persistent connections along with cookies and headers. 

The major changes in this PR are:

1. The constructor now includes an additional, optional argument `server`, a Boolean through which the user can specify whether they wish to instantiate a class for use locally or on a server.
2. The imports have been shifted inside the constructor. Depending on whether the user wants to run their code locally or on server, they only need the `requests` library or the `httpx[https]` library installed. In case these libraries are not present, a warning is raised and the other library is tried out. An exception is raised only when neither of the two libraries are found.
3. The `__getCookies` and `__setCookies` methods have been modified to check whether the `server` parameter is true or not and execute different code appropriately. 
4. The `httpx` library uses an `httpx.Cookies` object to store cookies while `requests` uses `requests.cookies.CookieJar` which is a dictionary-like iterable object. Both of these use `http.cookiejar.CookieJar` internally and are essentially wrappers with some added functionality. Hence, a generic function has been added to check for expiry of these cookies which can be called for both server and local versions inside `__hasCookiesExpired`.
5. The `__download` method has been modified, since the `get` method of `Client` does not support a `stream` argument. Instead, it has a separate method for streaming requests.  Hence, the appropriate method is called depending on what type of an object we are calling it on. 


The minor changes made to support the above functionality and otherwise are:

1. I've imported the `warnings` module and added some generic code along with it to ensure that warnings are displayed with pretty formatting.
2. In line with the principles of OOP:
    1. The `session` attribute of NSE is the most important attribute object of the class. All the methods are called with this object. However, we do not expect a user to use it directly, in fact if the user uses and modifies it directly, it can have unintended consequences. Hence, it has been converted to a private attribute `__sesion`
    2. It is best practice to call static methods directly and not on class instances. Hence, calls to static methods such as `__hasCookiesExpired` should be called as `NSE.__hasCookiesExpired` and not `self.__hasCookiesExpired`.
 3. The type of the response returned by calling `get` on a `Session` instance and a `Client` instance are different. The `Client` version does not have an attribute `ok`. All this does it check whether the status code of the response is not erroneous. In line with the standards specified in [this documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status), it is better to check the status code directly, since that is an attribute supported by both classes.

I have tested the working of this code on local and AWS EC2 (server) instances and all API calls seem to be working fine. 