### PR TITLE
Added a function to fetch historical India VIX data

### DIFF
--- a/src/nse/NSE.py
+++ b/src/nse/NSE.py
@@ -1438,7 +1438,7 @@ class NSE:
         if to_date < from_date:
             raise ValueError("The from date must occur before the to date")
 
-        date_chunks = NSE.__split_date_range(from_date, to_date)
+        date_chunks = NSE.__split_date_range(from_date, to_date, 100)
 
         data = []
 

--- a/src/nse/NSE.py
+++ b/src/nse/NSE.py
@@ -1438,7 +1438,7 @@ class NSE:
         if to_date < from_date:
             raise ValueError("The from date must occur before the to date")
 
-        date_chunks = NSE.__split_date_range(from_date, to_date, 100)
+        date_chunks = NSE.__split_date_range(from_date, to_date)
 
         data = []
 
@@ -1454,5 +1454,64 @@ class NSE:
                     },
                 ).json()["data"]
             )
+
+        return data
+    
+    def fetch_historical_vix_data(
+        self,
+        from_date: Optional[date] = None,
+        to_date: Optional[date] = None,
+    ) -> List[Dict]:
+        """
+        Downloads the historical India VIX within a given date range from ``from_date`` to ``to_date``.
+
+        The data is returned as a JSON object, where the primary data is stored as a list of rows (indexed starting at 0).
+
+        Each row is represented as a dict, with column names as keys and their corresponding values.
+
+        The date is stored under the key ``EOD_TIMESTAMP``.
+
+        :param from_date: The starting date from which we fetch the data. If None, the default date is 30 days from ``to_date``.
+        :type from_date: datetime.date
+        :param to_date: The ending date upto which we fetch the data. If None, today's date is taken by default.
+        :type to_date: datetime.date
+
+        :raise ValueError: if ``from_date`` is greater than ``to_date``
+        :raise TypeError: if ``from_date`` or ``to_date`` is not of type datetime.date
+
+        :return: Data as a list of rows, each row as dictionary with key as column name mapped to the value
+        :rtype: List[Dict]
+        """
+        if from_date and not isinstance(from_date, date):
+            raise TypeError(
+                "Starting date must be an object of type datetime.date"
+            )
+
+        if to_date and not isinstance(to_date, date):
+            raise TypeError(
+                "Ending date must be an object of type datetime.date"
+            )
+
+        if not to_date:
+            to_date = date.today()
+
+        if not from_date:
+            from_date = to_date - timedelta(30)
+
+        if to_date < from_date:
+            raise ValueError("The from date must occur before the to date")
+
+        date_chunks = NSE.__split_date_range(from_date, to_date)
+
+        data = []
+
+        for chunk in date_chunks:
+            data += self.__req(
+                    url=f"{self.base_url}/historical/vixhistory",
+                    params={
+                        "from": chunk[0].strftime("%d-%m-%Y"),
+                        "to": chunk[1].strftime("%d-%m-%Y"),
+                    },
+                ).json()["data"]
 
         return data


### PR DESCRIPTION
I am opening a new PR which is very similar to #8 but replace stocks with Vix. 

NSE provides historical India VIX , or simply vix data [over here](https://www.nseindia.com/reports-indices-historical-vix). Due to the similar nature of the API, I have re-used the code from the `fetch_equity_historical_data` for this function, just changing the API endpoint it hits. 

The minor changes here are:

-  Changing the chunk size when we split our date range into chunks. This API endpoint allows us to put a range of up to 365 days unlike the equity endpoint which would allow a max of 70 days. We exploit this to make fewer API calls and fetch larger chunks.
- The `from` and `to` parameters of the API endpoint are no longer optional. We still keep them optional in our API endpoint to play it nice for the user, so that they can fetch 1 month of vix data by default. 