### PR TITLE
Added API endpoint to fetch list of FnO equities

### DIFF
--- a/src/nse/NSE.py
+++ b/src/nse/NSE.py
@@ -1699,3 +1699,17 @@ class NSE:
             data["turnover"] += dct["indexTurnoverRecords"]
 
         return data
+    
+    def fetch_fno_underlying(self) -> Dict[str, List[Dict[str, str]]]:
+        """
+        Fetches the indices and stocks for which FnO contracts are available to trade
+        
+        Reference URL: https://www.nseindia.com/market-data/securities-available-for-trading
+        
+        :return: A dictionary with keys '`IndexList`' and '`UnderlyingList`'. The values are the list of indices and stocks along
+        with their names and tickers respectively in alphabetical order for stocks. 
+        :rtype: Dict[str, List[Dict[str, str]]]
+        """
+        url = f"{self.base_url}/underlying-information"
+        data = self.__req(url).json()["data"]
+        return data


### PR DESCRIPTION
This is a tiny PR for a new API endpoint I have added. It pulls the list of FnO securities in the equity segment available for trading at any time. The exposed endpoint is [this one](https://www.nseindia.com/api/underlying-information). 