### PR TITLE
Add financial_results and results_comparison endpoints

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -176,6 +176,10 @@ Corporate Announcements and Actions
 
 .. automethod:: nse.NSE.annual_reports
 
+.. automethod:: nse.NSE.financial_results
+
+.. automethod:: nse.NSE.results_comparison
+
 Futures and Options (FnO)
 -------------------------
 

--- a/src/nse/NSE.py
+++ b/src/nse/NSE.py
@@ -746,6 +746,97 @@ class NSE:
             f"{self.base_url}/annual-reports", params=dict(index=segment, symbol=symbol)
         ).json()
 
+    def financial_results(
+        self,
+        index: Literal["equities", "sme", "debt", "mf"] = "equities",
+        period: Literal["Quarterly", "Annual", "Half-Yearly"] = "Quarterly",
+        symbol: Optional[str] = None,
+        from_date: Optional[datetime] = None,
+        to_date: Optional[datetime] = None,
+    ) -> List[Dict]:
+        """Get corporate financial-results filings (metadata) for a date range.
+
+        Returns one row per filing with broadcast/filing dates, the quarter
+        covered (``fromDate`` / ``toDate``), ``relatingTo`` (e.g. "Third Quarter"),
+        consolidated/audited flags, and an optional XBRL link. Revenue and EPS
+        figures are **not** included here — use :meth:`results_comparison` for
+        the numeric P&L summary per symbol.
+
+        `Sample response <https://github.com/BennyThadikaran/NseIndiaApi/blob/main/src/samples/financial_results.json>`__
+
+        Reference URL:
+            https://www.nseindia.com/companies-listing/corporate-filings-financial-results
+
+        :param index: One of ``equities``, ``sme``, ``debt`` or ``mf``. Default ``equities``
+        :type index: str
+        :param period: One of ``Quarterly``, ``Annual`` or ``Half-Yearly``. Default ``Quarterly``
+        :type period: str
+        :param symbol: Optional stock symbol to filter filings
+        :type symbol: str or None
+        :param from_date: Optional start of broadcast-date window (inclusive)
+        :type from_date: datetime.datetime
+        :param to_date: Optional end of broadcast-date window (inclusive)
+        :type to_date: datetime.datetime
+        :raise ValueError: if ``from_date`` is greater than ``to_date``
+        :return: A list of financial-results filing records
+        :rtype: list[dict]
+        """
+        fmt = "%d-%m-%Y"
+
+        params: Dict[str, Any] = {
+            "index": index,
+            "period": period,
+        }
+
+        if symbol:
+            params["symbol"] = symbol.upper()
+
+        if from_date and to_date:
+            if from_date > to_date:
+                raise ValueError("'from_date' cannot be greater than 'to_date'")
+
+            params.update(
+                {
+                    "from_date": from_date.strftime(fmt),
+                    "to_date": to_date.strftime(fmt),
+                }
+            )
+
+        url = f"{self.base_url}/corporates-financial-results"
+
+        return self._req(url, params=params).json()
+
+    def results_comparison(self, symbol: str) -> Dict:
+        """Get quarterly financial results comparison (P&L summary) for a symbol.
+
+        NSE's endpoint path is spelled ``results-comparision`` (official typo).
+
+        The response contains a ``resCmpData`` list — typically the last ~5
+        quarters — with revenue, net profit and EPS fields. Monetary amounts are
+        in **Rupees Lakhs** (divide by 100 for Crores).
+
+        `Sample response <https://github.com/BennyThadikaran/NseIndiaApi/blob/main/src/samples/results_comparison.json>`__
+
+        Reference URL:
+            https://www.nseindia.com/companies-listing/corporate-filings-financial-results
+
+        .. code-block:: python
+
+            with NSE("") as nse:
+                data = nse.results_comparison("RELIANCE")
+                for row in data["resCmpData"]:
+                    print(row["re_to_dt"], row.get("re_total_inc"), row.get("re_net_profit"))
+
+        :param symbol: Stock symbol (e.g. ``RELIANCE``, ``HDFCBANK``)
+        :type symbol: str
+        :return: Dictionary with ``resCmpData`` — list of quarter rows
+        :rtype: dict
+        """
+        return self._req(
+            f"{self.base_url}/results-comparision",
+            params={"symbol": symbol.upper()},
+        ).json()
+
     def shareholding(
         self, symbol: str, index: Literal["equities", "sme"] = "equities"
     ) -> List[dict]:

--- a/src/samples/financial_results.json
+++ b/src/samples/financial_results.json
@@ -1,0 +1,18 @@
+[
+  {
+    "symbol": "RELIANCE",
+    "series": "EQ",
+    "isin": "INE002A01018",
+    "comp": "Reliance Industries Limited",
+    "period": "Quarterly",
+    "fromDate": "01-Oct-2024",
+    "toDate": "31-Dec-2024",
+    "relatingTo": "Third Quarter",
+    "financialYear": "01-Apr-2024 To 31-Mar-2025",
+    "consolidated": "Consolidated",
+    "audited": "Un-Audited",
+    "filingDate": "16-Jan-2025 15:30",
+    "broadCastDate": "16-Jan-2025 15:29:51",
+    "xbrl": "https://nsearchives.nseindia.com/corporate/xbrl/example.xml"
+  }
+]

--- a/src/samples/results_comparison.json
+++ b/src/samples/results_comparison.json
@@ -1,0 +1,25 @@
+{
+  "resCmpData": [
+    {
+      "re_from_dt": "01-Oct-2024",
+      "re_to_dt": "31-Dec-2024",
+      "re_create_dt": "16-JAN-2025",
+      "re_total_inc": "13147400",
+      "re_net_sale": "12826000",
+      "re_net_profit": "872100",
+      "re_con_pro_loss": "872100",
+      "re_basic_eps_for_cont_dic_opr": "6.44",
+      "re_dilut_eps_for_cont_dic_opr": "6.44",
+      "re_bank": "N"
+    },
+    {
+      "re_from_dt": "01-Jul-2024",
+      "re_to_dt": "30-Sep-2024",
+      "re_create_dt": "14-OCT-2024",
+      "re_total_inc": "13433100",
+      "re_net_profit": "771300",
+      "re_basic_eps_for_cont_dic_opr": "11.4",
+      "re_bank": "N"
+    }
+  ]
+}

--- a/tests/test_nse_financial_results.py
+++ b/tests/test_nse_financial_results.py
@@ -1,0 +1,81 @@
+import json
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from context import NSE
+
+DIR = Path(__file__).parent
+SAMPLES = DIR.parent / "src" / "samples"
+
+
+class TestNseFinancialResults(unittest.TestCase):
+    """Unit tests for financial_results and results_comparison (mocked _req)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nse = NSE(download_folder=DIR, server=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.nse.exit()
+
+    def _mock_req_json(self, payload):
+        mock = MagicMock()
+        mock.return_value.json.return_value = payload
+        self.nse._req = mock
+        return mock
+
+    def test_financial_results_params(self):
+        sample = json.loads((SAMPLES / "financial_results.json").read_text())
+        mock = self._mock_req_json(sample)
+
+        from_dt = datetime(2025, 1, 1)
+        to_dt = datetime(2025, 3, 31)
+
+        result = self.nse.financial_results(
+            index="equities",
+            period="Quarterly",
+            symbol="reliance",
+            from_date=from_dt,
+            to_date=to_dt,
+        )
+
+        self.assertEqual(result, sample)
+        mock.assert_called_once()
+        _, kwargs = mock.call_args
+        self.assertEqual(
+            kwargs["params"],
+            {
+                "index": "equities",
+                "period": "Quarterly",
+                "symbol": "RELIANCE",
+                "from_date": "01-01-2025",
+                "to_date": "31-03-2025",
+            },
+        )
+
+    def test_financial_results_date_validation(self):
+        with self.assertRaises(ValueError):
+            self.nse.financial_results(
+                from_date=datetime(2025, 3, 1),
+                to_date=datetime(2025, 1, 1),
+            )
+
+    def test_results_comparison(self):
+        sample = json.loads((SAMPLES / "results_comparison.json").read_text())
+        mock = self._mock_req_json(sample)
+
+        result = self.nse.results_comparison("reliance")
+
+        self.assertEqual(result, sample)
+        self.assertIn("resCmpData", result)
+        mock.assert_called_once()
+        args, kwargs = mock.call_args
+        self.assertTrue(args[0].endswith("/results-comparision"))
+        self.assertEqual(kwargs["params"], {"symbol": "RELIANCE"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: Add quarterly financial results endpoints

## Summary

Adds two methods for NSE's corporate financial-results APIs, matching the
existing style of `actions()`, `announcements()` and `boardMeetings()`:

| Method | NSE endpoint | Purpose |
|--------|--------------|---------|
| `financial_results()` | `/api/corporates-financial-results` | Filing calendar (who reported, when, which quarter, XBRL link) |
| `results_comparison()` | `/api/results-comparision` | Per-symbol P&L summary (`resCmpData`: revenue, net profit, EPS in Lakhs) |

These endpoints are already used in production pipelines but were missing from
the library. NSE spells the comparison path **comparision** (typo) — the
public Python method is correctly named `results_comparison()`.

## Usage

```python
from datetime import datetime
from nse import NSE

with NSE(download_folder="./data", server=True) as nse:
    # Recent quarterly filings (metadata)
    filings = nse.financial_results(
        index="equities",
        period="Quarterly",
        from_date=datetime(2025, 1, 1),
        to_date=datetime(2025, 3, 31),
    )

    # Numeric P&L for one symbol (~5 most recent quarters)
    data = nse.results_comparison("RELIANCE")
    for row in data["resCmpData"]:
        print(row["re_to_dt"], row.get("re_total_inc"), row.get("re_net_profit"))
```

## Files changed

- `src/nse/NSE.py` — two new methods (insert after `annual_reports`)
- `src/samples/financial_results.json` — sample response
- `src/samples/results_comparison.json` — sample response
- `tests/test_nse_financial_results.py` — mocked unit tests (params + date validation)
- `docs/source/api.rst` — Sphinx automethod entries

## Test plan

```bash
pip install nse[local]
python -m unittest tests.test_nse_financial_results -v
```

Optional live smoke test (requires network + valid NSE session):

```python
from datetime import datetime, timedelta
from nse import NSE

with NSE(".", server=True) as nse:
    to = datetime.now()
    frm = to - timedelta(days=90)
    print(len(nse.financial_results(from_date=frm, to_date=to)))
    print(nse.results_comparison("RELIANCE")["resCmpData"][0]["re_to_dt"])
```

## Notes

- Monetary fields in `resCmpData` are **Rupees Lakhs** (not Crores).
- `financial_results` returns filing metadata only; use `results_comparison` for numbers.
- Banks may expose different field names; callers should use `.get()` with fallbacks.
